### PR TITLE
Fixed bad pathing issue

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -12,15 +12,15 @@ var app = express();
 //
 // Static directories
 //
-app.use("/angular", express.static("../node_modules/angular"));
-app.use("/angular-animate", express.static("../node_modules/angular-animate"));
-app.use("/animate.css", express.static("../node_modules/animate.css"));
-app.use("/jquery", express.static("../node_modules/jquery/dist"));
-app.use("/bootstrap", express.static("../node_modules/bootstrap/dist"));
-app.use("/font-awesome", express.static("../node_modules/font-awesome"))
-app.use("/controllers", express.static("../client/controllers"));
-app.use("/stylesheets", express.static("../client/stylesheets"));
-app.use(express.static("../client/views"));
+app.use("/angular", express.static(__dirname + "/../node_modules/angular"));
+app.use("/angular-animate", express.static(__dirname + "/../node_modules/angular-animate"));
+app.use("/animate.css", express.static(__dirname + "/../node_modules/animate.css"));
+app.use("/jquery", express.static(__dirname + "/../node_modules/jquery/dist"));
+app.use("/bootstrap", express.static(__dirname + "/../node_modules/bootstrap/dist"));
+app.use("/font-awesome", express.static(__dirname + "/../node_modules/font-awesome"))
+app.use("/controllers", express.static(__dirname + "/../client/controllers"));
+app.use("/stylesheets", express.static(__dirname + "/../client/stylesheets"));
+app.use(express.static(__dirname + "/../client/views"));
 app.use(bodyParser.json());
 
 //


### PR DESCRIPTION
This pull request fixes the issue @CCappsDevelopment was facing while trying to run the various commands to start the server.
- `grunt` worked because it specifies the current working directory as `__dirname + "/server"`
- `node server/server` from root failed because the cwd is not set, and assumed to be root
  -`node server` while in the server subdirectory worked because cwd was assumed to be /server

The fix was to go back to using `__dirname` when specifying static directories in the server file. I ran into another issue where I forgot to add a leading `/` between `__dirname` and `../`. Everything seems to be working now. We may still want to use `path.join()` to be safe in the future.
