### PR TITLE
Enabled shortcut form submission

### DIFF
--- a/client/views/contacts/contacts.index.html
+++ b/client/views/contacts/contacts.index.html
@@ -1,46 +1,49 @@
 <div id="contact-index" class="container" ng-controller="ContactController as contactCtrl">
     <h1>Contact List</h1>
-    <table class="table">
-        <thead>
-            <tr>
-                <th>Name</th>
-                <th>Email</th>
-                <th>Number</th>
-                <th>Action</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td><input class="form-control" ng-model="contactCtrl.formData.name"/></td>
-                <td><input class="form-control" ng-model="contactCtrl.formData.email"/></td>
-                <td><input class="form-control" ng-model="contactCtrl.formData.number"/></td>
-                <td>
-                    <button class="btn btn-success" ng-click="contactCtrl.updateContact()">
-                        <span class="fa fa-plus"></span>
-                    </button>
-                </td>
-                <td ng-show="contactCtrl.isEditing">
-                    <button class="btn btn-danger" ng-click="contactCtrl.stopEditing()">
-                        <span class="fa fa-times"></span>
-                    </button>
-                </td>
-            </tr>
-            <tr class="contact-row" ng-repeat="contact in contactCtrl.contacts">
-                <td>{{contact.name}}</td>
-                <td>{{contact.email}}</td>
-                <td>{{contact.number}}</td>
-                <td>
-                    <button class="btn btn-danger" ng-click="contactCtrl.deleteContact(contact.id)">
-                        <span class="fa fa-trash-o"></span>
-                    </button>
-                </td>
-                <td>
-                    <button class="btn btn-warning" ng-click="contactCtrl.startEditing(contact)">
-                        <span class="fa fa-pencil"></span>
-                    </button>
-                </td>
-            </tr>
-        </tbody>
-    </table>
+    <form ng-submit="contactCtrl.updateContact()">
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Email</th>
+                    <th>Number</th>
+                    <th>Action</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><input class="form-control" ng-model="contactCtrl.formData.name"/></td>
+                    <td><input class="form-control" ng-model="contactCtrl.formData.email"/></td>
+                    <td><input class="form-control" ng-model="contactCtrl.formData.number"/></td>
+                    <td>
+                        <button type="submit" class="btn btn-success">
+                            <span class="fa fa-plus"></span>
+                        </button>
+                    </td>
+                    <td ng-show="contactCtrl.isEditing">
+                        <!-- type="button" required for html to not treat it as a submit button -->
+                        <button type="button" class="btn btn-danger" ng-click="contactCtrl.stopEditing()">
+                            <span class="fa fa-times"></span>
+                        </button>
+                    </td>
+                </tr>
+                <tr class="contact-row" ng-repeat="contact in contactCtrl.contacts">
+                    <td>{{contact.name}}</td>
+                    <td>{{contact.email}}</td>
+                    <td>{{contact.number}}</td>
+                    <td>
+                        <button type="button" class="btn btn-danger" ng-click="contactCtrl.deleteContact(contact.id)">
+                            <span class="fa fa-trash-o"></span>
+                        </button>
+                    </td>
+                    <td>
+                        <button type="button" class="btn btn-warning" ng-click="contactCtrl.startEditing(contact)">
+                            <span class="fa fa-pencil"></span>
+                        </button>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </form>
 </div>

--- a/todo.md
+++ b/todo.md
@@ -6,9 +6,9 @@ Since I'm not using any sort of task board for this simple project, I'm going to
 
 The application should do some validation on the data, maybe client and server both.
 
-I should be able to hit `return` instead of having to click on the add button.
-
 The client-side controllers need to be more verbose, and handle errors.
+
+The add contact button icon should change from a plus to a check when editing a contact.
 
 ## Style
 


### PR DESCRIPTION
This pull request enables the use to submit the form data (either for adding a contact or editing one) by pressing the `return` key (or any other default form submission method, like the `go` key on mobile).

This was accomplished by placing the table in form tags, adding `ngSubmit` directive to it and setting the action to the `updateContact()` function, and explicitly setting the `type` attribute on the add button to "submit" and all other buttons' to "button."
