### PR TITLE
Prevent removal of editing contact

### DIFF
--- a/client/views/contact/contact.index.html
+++ b/client/views/contact/contact.index.html
@@ -33,7 +33,7 @@
                     <td>{{contact.email}}</td>
                     <td>{{contact.number}}</td>
                     <td>
-                        <button type="button" class="btn btn-danger" ng-click="contactCtrl.deleteContact(contact.id)">
+                        <button type="button" class="btn btn-danger" ng-disabled="contactCtrl.isEditing" ng-click="contactCtrl.deleteContact(contact.id)">
                             <span class="fa fa-trash-o fa-fw"></span>
                         </button>
                     </td>


### PR DESCRIPTION
Added `ng-disabled` directive to delete button that prevents user from removing contacts while they have one selected for editing. Otherwise, the user would be able to bomb the app by submitting the edited contact after it no longer existed, and the server would be unable to find the contact's ID to update it.

Of course, I could have handled that case gracefully, and I still will, but this is the most immediately effective (and graceful) solution.
